### PR TITLE
Fixed Issue #2

### DIFF
--- a/src/intervalSetLib/number.cpp
+++ b/src/intervalSetLib/number.cpp
@@ -27,12 +27,9 @@
 #include <sstream>
 #include <iomanip>
 
-#include <iostream>
-
 //-----------------------------------------------------------------------------
 // Static Members
 //-----------------------------------------------------------------------------
-
 
 const DNumber DNumber::plus_inf(1, 0);
 const DNumber DNumber::minus_inf(-1, 0);

--- a/src/intervalSetLib/number.h
+++ b/src/intervalSetLib/number.h
@@ -77,6 +77,10 @@ public:
     static const DNumber minus_inf;
 
 private:
+    std::string mpq_to_smt2(const mpq_class &value) const;
+    ///< returns SmtLibv2.0 representation of an mpq value,
+    ///< NOTE: assumes the value is not infinite or indeterminate
+
     mpq_class val_;
     mpq_class eps_;
 

--- a/src/setExpr.cpp
+++ b/src/setExpr.cpp
@@ -14,7 +14,13 @@ Set::Set(Expr_node* a, Expr_node* b){
 	Literal* lb = a->eval();
 	Literal* ub = b->eval();
 
-	Interval s = Interval(lb->toString(),ub->toString());
+    std::string lb_repr = lb->toString();
+    std::string ub_repr = ub->toString();
+
+    DNumber lb_num = DNumber(lb_repr);
+    DNumber ub_num = DNumber(ub_repr);
+
+	Interval s = Interval(lb_num, ub_num);
 	set = new IntervalSet(s);
 }
 

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -15,7 +15,7 @@ Symbol::Symbol(DOMAIN_TYPE dom){
     //TODO:: settare il range al massimo dei valori consentiti "(-inf,+inf)" o (-10kk, 10kk)
     //range = new IntervalSet(-inf,+inf);
     index = NULL;
-    range = NULL;
+    range = new IntervalSet(Interval(DNumber::minus_inf, DNumber::plus_inf));
     value = NULL;
 }
 
@@ -29,6 +29,9 @@ void Symbol::setRange(Expr_node* set){
 
     //needed in set_expr: conversion from Expr_node*(ARR_INDEX) to Symbol
     //something like:
+    if (this->range) {
+        delete range;
+    }
     this->range = ((Set*)(set))->exportRange();
 }
 
@@ -65,7 +68,7 @@ void Symbol::importIndexes(std::queue<Symbol*>* list){
 
 IntervalSet* Symbol::exportIndex(){
     IntervalSet* tmp = this->range;
-    this->range = NULL;
+    this->range = NULL; // TODO: memory leak?
     delete this;
     return tmp;
 }


### PR DESCRIPTION
The output of 

```
var 0..5: y;
var float: z;
var 1.21..1.5: t;
solve satisfy;

```

is now:

```
(declare-fun y () Int )
(assert (and (>= y 0) (<= y 5)))
(declare-fun z () Real )
(assert (and (>= z (- 1000000000)) (<= z 1000000000)))
(declare-fun t () Int )
(assert (and (>= t (/ 121 100)) (<= t (/ 3 2))))

```

---

Please see comment 'TODO: memory leak?' in 'symbol.cpp'. It's not clear to me who has the ownership of range within your model. 
