### PR TITLE
Minor Adjustments

### DIFF
--- a/src/intervalSetLib/number.cpp
+++ b/src/intervalSetLib/number.cpp
@@ -35,10 +35,10 @@ const DNumber DNumber::plus_inf(1, 0);
 const DNumber DNumber::minus_inf(-1, 0);
 const mpz_class DNumber::zero_(0);
 
-const std::string minus_inf_repr = "(- 1000000000)"; // "-inf"
-const std::string plus_inf_repr = "1000000000";      // "+inf"
-const std::string indeterminate_repr = "(/ 0 0)";    // "0/0"
-const std::string eps_repr = "(/ 1 1000000000)";     // "eps"
+static const std::string plus_inf_repr = "10000000";      // "+inf"
+static const std::string minus_inf_repr = "(- " + plus_inf_repr + ")"; // "-inf"
+static const std::string indeterminate_repr = "(/ 0 0)";    // "0/0"
+static const std::string eps_repr = "(/ 1 " + plus_inf_repr + ")";     // "eps"
 
 //-----------------------------------------------------------------------------
 // Init/Deinit

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -109,17 +109,29 @@ void Symbol::decideName(string name,DNumber i,DNumber j,DNumber k){
 
 void Symbol::printRange(string name, bool isArray, DNumber i,DNumber j,DNumber k, IntervalSet* range){
     if(! isArray){
-        std::cout << "(assert (and (>= " << name << " " << ((*range).lower().is_inf() ? "(- 0 10000000)" : (*range).lower().to_str()) << ") (<= " << name << " " << ((*range).upper().is_inf() ? "10000000" : (*range).upper().to_str()) << ")))" << std::endl;
-    }else{
+        std::cout << "(assert (and (<= "
+                  << range->lower().to_str() << " "
+                  << name << ") (<= " << name << " "
+                  << range->upper().to_str() << ")))"
+                  << std::endl;
+    } else {
+        // EDIT: stronger, can be more effective for smt2 theory solvers
+        std::string name = printName(name, i, j, k);
+        std::cout << "(assert (and (<= "
+                  << range->lower().to_str() << " "
+                  << name << ") (<= " << name << " "
+                  << range->upper().to_str() << ")))" << std::endl;
         if(range->is_fragmented()){
             std::cout << "(assert (or ";
-            for (IntervalSet::subset_iterator it = (*range).subset_begin(), end = (*range).subset_end();
-                it != end; ++it) {
-                std::cout << "(and  (>= " << printName(name,i,j,k) << " " << (it->lower().is_inf() ? "(- 0 10000000)" : it->lower().to_str()) <<") (<= "<< printName(name,i,j,k) << " " << (it->upper().is_inf() ? "10000000" : it->upper().to_str()) <<")) ";
+            for (IntervalSet::subset_iterator it = range->subset_begin(),
+                    end = range->subset_end(); it != end; ++it) {
+                std::cout << "(and  (<= "
+                          << it->lower().to_str() << " "
+                          << name << ") (<= "<< name << " "
+                          << it->upper().to_str()
+                          <<")) ";
             }
             std::cout << "))" << endl;
-        }else{
-            std::cout << "(assert (and (>= " << printName(name,i,j,k) << " " << ((*range).lower().is_inf() ? "(- 0 10000000)" : (*range).lower().to_str()) << ") (<= " << printName(name,i,j,k) << " " << ((*range).upper().is_inf() ? "10000000" : (*range).upper().to_str()) << ")))" << std::endl;
         }
     }
 }


### PR DESCRIPTION
- +/- inf representation, and the numbers' smt2 representation in general, should be delegated to the Number class,  so keep a unique control point of its behaviour
- transformed (>= VAR CONST) into (<= CONST VAR), easier to read
- forced generation of 'loose' boundaries even when domain is fragmented, as smt2 theory solvers can benefit from free from this information without resorting to internal deduction to learn it.
